### PR TITLE
Teste para hospedagem da aplicação numa instância EC2

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,9 @@
+# Estas são as variáveis de ambiente. Elas serão importadas para o 
+# arquivo environmentVariables.js que esta dentro da pasta config, 
+# na raiz do sistema, e em seguida utilizadas em diversas partes do 
+# onde forem necessárias variáveis de ambiente
+
+PORT=3000
+HOST=ec2-54-152-172-224.compute-1.amazonaws.com
+NODE_ENV=dev
+DATABASE_URL=postgres://ienuhcvmpjrnaj:dd365f60f5f946f244708b989da38e366cd8b49e44547275a9aa317b9a24a583@ec2-54-159-22-90.compute-1.amazonaws.com:5432/d2m4dcvscp7jt7

--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,7 @@ typings/
 .yarn-integrity
 
 # dotenv environment variables file
-.env
+#.env
 .env.test
 .env.prod
 .env.dev


### PR DESCRIPTION
- Adicionado DNS público da instância EC2 ao arquivo .env
- Retirado arquivo .env do .gitignore para facilitar as configurações em ambiente de laboratório (efêmero)